### PR TITLE
Subtle fix to query params for views

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -141,7 +141,7 @@ module.exports = exports = nano = function database_module(cfg) {
         var value;
         for(var key in prms) {
           if(prms.hasOwnProperty(key)) {
-            value = prms[key]
+            value = prms[key];
             q_str.push(key+"="+qs.escape(value));
           }
         }


### PR DESCRIPTION
I found a really subtle bug when querying a view with a key that had a value of type Number. It simply passed along the value as key=123, when it should have been key="123". According to the CouchDB API, all values should be JSON encoded.

I am submitting this as a pull request because I am not entirely sure how to write tests, and they were not all passing when I pulled locally :(

Let me know what you think!

Also, sorry if this is messing with formatting slightly, I am copy/pasting my changes into the Github text editor, thats probably what happened :/
