### PR TITLE
minor pathname bug

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -556,7 +556,7 @@ module.exports = exports = nano = function database_module(cfg) {
                      };
 
   // does the user want a database, or nano?
-  if(!_.isEmpty(path.pathname.split('/')[1])) {
+  if(path.pathname && !_.isEmpty(path.pathname.split('/')[1])) {
     db = path.pathname.split('/')[1];
     cfg.url = path.protocol + '//' + path.host; // reset url
     return document_module(db);


### PR DESCRIPTION
I've noticed that if you cfg.url =  http://user:pass@hostname.com without a slash, you can cause the URL parser to not return a pathname attribute, which causes a split on undefined error. This should make sure we only split, in the event of a pathname.
