### PR TITLE
create a stub object if one is missing, in a failure scenario 

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -164,6 +164,7 @@ module.exports = exports = nano = function database_module(cfg) {
           if(verbose) { 
             console.log({err: 'couch', body: parsed, headers: rh}); 
           }
+          if (!parsed) { parsed = {}; } // if HEAD request, body will be undefined
           callback(error.couch(parsed.reason,parsed.error,req,status_code),
             parsed, rh);
         }


### PR DESCRIPTION
likely, in 404 response w/ HEAD requests.
related to #47.
