### PR TITLE
Allow function value (handy for design documents)

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -149,7 +149,13 @@ module.exports = exports = nano = function database_module(cfg) {
       }
       else {
         try {
-          req.body = JSON.stringify(opts.body);
+          req.body = JSON.stringify(opts.body, function (key, value) {
+            if (typeof(value) === 'function') {
+              return value.toString();
+            } else {
+              return value;
+            }
+          });
         } catch (ex5) { 
           ex5.message = "couldn't json.stringify the body you provided";
           return error.request_err(ex5, 'jsonstringify', {}, callback);

--- a/tests/doc/insert.js
+++ b/tests/doc/insert.js
@@ -33,7 +33,7 @@ var ensure   = require('ensure')
         'content-type': 'application/json',
         'content-length': '95',
         'cache-control': 'must-revalidate' })
-    .put('/' + db_name('b') + '/some%2Fpath', {"foo": "bar"})
+    .put('/' + db_name('b') + '/some%2Fpath', {"foo": "bar", "fn": "function () { return true; }"})
     .reply(201, "{\"ok\": true,\"id\": \"some/path\",\"rev\": \"1-4c6114c65e295552ab1019e2b046b10e\"}\n", 
       { server: 'CouchDB/1.1.1 (Erlang OTP/R14B04)',
         location: cfg.url + '/' + db_name('b') + '/some/path',
@@ -61,7 +61,7 @@ tests.insert_doc_ok = function (e,b) {
 
 tests.insert_doc_path = function (callback) {
   nano.db.create(db_name("b"), function () {
-    db("b").insert({foo: "bar"}, 'some/path', callback);
+    db("b").insert({foo: "bar", fn: function () { return true; }}, 'some/path', callback);
   });
 };
 


### PR DESCRIPTION
Design documents usually contain lengthy functions which are represented as a function and not as a multi-line string.
Prior to this patch, nano strips out all properties having function as value at this line in nano,js:
  req.body = JSON.stringify(opts.body);

It would be handy if nano allows function values and convert them to strings before sending the documents over to Couch.
