### PR TITLE
Adds "headers" to options for passing in request headers

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -124,11 +124,11 @@ module.exports = exports = nano = function database_module(cfg) {
       req.uri = u.resolve(req.uri, opts.db);
     }
 
-	if (opts.headers) {
-		for (var k in opts.headers) {
-			req.headers[k] = opts.headers[k];
-		}
-	}
+    if (opts.headers) {
+      for (var k in opts.headers) {
+        req.headers[k] = opts.headers[k];
+      }
+    }
 
     if(opts.path) {
       req.uri += "/" + opts.path;


### PR DESCRIPTION
Hi dscape,

this pull request refers to our "discussion" on twitter: https://twitter.com/streunerlein/status/202055920593809409

I've added an additional field "headers" to 'opts' (which you pass in to relax/request). Doing this, I could resolve the caching issues i had:
(example) https://gist.github.com/2784839

The problem is basically, that when piping attachments with nano atm, the headers of the request do not get piped to CouchDb. CouchDb uses the If-None-Match-Header of the request to determine if it has to send the attachment or just a 304 Not modified (to let the browser use its cache).

Try it out, it works here for me :) Nice Caching!

greeting,

Dominique
