### PR TITLE
Updated section in README.md pertaining to db.head(doc, [callback]).  

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,12 +315,12 @@ alice.get('rabbit', { revs_info: true }, function(err, body) {
 });
 ```
 
-### db.head(docname, [params], [callback])
+### db.head(docname, [callback])
 
 same as `get` but lightweight version that returns headers only.
 
 ``` js
-alice.head('rabbit', { revs_info: true }, function(err, _, headers) {
+alice.head('rabbit', function(err, _, headers) {
   if (!err)
     console.log(headers);
 });


### PR DESCRIPTION
The second parameter to this call should be a callback not a parameter object according to the source, line 568.
