### PR TITLE
Added support for couchdb ddoc list functions

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -768,6 +768,37 @@ module.exports = exports = nano = function database_module(cfg) {
       }
     }
 
+
+   /*
+    * calls a list function
+    *
+    * @param {design_name:string} design document name
+    * @param {list_name:string} list function to call
+    * @param {view_name:string} view to call
+    * @param {params:object:optional} additions to the querystring
+    *
+    * @see relax
+    */
+    function list_view_docs(design_name,list_name,view_name,params,callback) {
+      if(typeof params === "function") {
+        callback = params;
+        params   = {};
+      }
+      var list_path = '_design/' + design_name + '/_list/' + list_name + "/" + view_name;
+      if (params.keys) {
+        var body = {keys: params.keys};
+        delete params.keys;
+        return relax(
+          { db: db_name, path: list_path
+          , method: "POST", params: params, body: body }, callback);
+      }
+      else {
+        return relax(
+          { db: db_name, path: list_path
+          , method: "GET", params: params },callback);
+      }
+    }
+
     /*
     * calls a show function
     *
@@ -921,6 +952,7 @@ module.exports = exports = nano = function database_module(cfg) {
       , destroy           : destroy_doc
       , bulk              : bulk_docs
       , list              : list_docs
+      , listView          : list_view_docs
       , fetch             : fetch_docs
       , config            : {url: cfg.url, db: db_name}
       , attachment        :


### PR DESCRIPTION
added support for list functions.
The name `list` is taken for all-documents view, so I had to improvise... :P

Maybe I'll figure the test suite and add test-coverage later.
In my project I just augmented the returned db-level object in my dal-wrapper module, and for honesty's sake - my augmentation does not implement the `if (params.keys)` part,
however, when my project got to production I decided to contribute this to the community, and while doing so, having a look on the internals of nano I decided to follow the pattern demonstrated here (and learnt something new about it :) )

cheers
