### PR TITLE
throw error if att_name is missing in destroy call

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -928,6 +928,13 @@ module.exports = exports = nano = function database_module(cfg) {
     * @see relax
     */
     function destroy_att(doc_name,att_name,rev,callback) {
+      if(typeof att_name !== 'string' && att_name !== '') {
+        return errs.handle(errs.create(
+          { "message": "att_name is not a string"
+            , "scope"  : "nano"
+            , "errid"   : "bad_params"
+          }), callback);
+      }
       return relax({ db: db_name, att: att_name, method: "DELETE"
                   , doc: doc_name, params: {rev: rev}},callback);
     }

--- a/tests/att/destroy.js
+++ b/tests/att/destroy.js
@@ -29,6 +29,19 @@ specify("att_destroy:test", timeout, function (assert) {
   });
 });
 
+specify("att_destroy:att_name_missing", timeout, function (assert) {
+  db.attachment.insert("new", "att2", "Hello World!", "text/plain",
+  function (error, att) {
+    assert.equal(error, undefined, "Should store the attachment");
+    assert.equal(att.ok, true, "Response should be ok");
+    assert.ok(att.rev, "Should have a revision number");
+    db.attachment.destroy("new", false, att.rev, function(error, response) {
+      assert.equal(error.errid, "bad_params", "Should throw error because att_name is not a string");
+      assert.equal(response, undefined, "No response should be given");
+    });
+  });
+});
+
 specify("att_destroy:teardown", timeout, function (assert) {
   nano.db.destroy("att_destroy", function (err) {
     assert.equal(err, undefined, "Failed to destroy database");

--- a/tests/fixtures/att/destroy.json
+++ b/tests/fixtures/att/destroy.json
@@ -15,6 +15,12 @@
   , "response" : "{ \"ok\": true, \"id\": \"new\" }"
   , "status"   : 201
   }
+, { "method"   : "put"
+  , "path"     : "/att_destroy/new/att2"
+  , "body"     : "\"Hello World!\""
+  , "status"   : 201
+  , "response" : "{\"ok\": true, \"id\": \"new\", \"rev\": \"1-921bd51\" }"
+  }
 , { "method"   : "delete"
   , "path"     : "/att_destroy"
   , "status"   : 200


### PR DESCRIPTION
As the att_name is used in constructing the url to send the DELETE call
to, using something like false or an empty string results in deleting
the whole document. This should not happen…
