### PR TITLE
Fixed typo - I think 'rabbit' is used consistently as the doc in the 'alice' db.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ alice.insert({ crazy: true }, 'rabbit', function(err, body) {
 removes revision `rev` of `docname` from couchdb.
 
 ``` js
-alice.destroy('alice', '3-66c01cdf99e84c83a9b3fe65b88db8c0', function(err, body) {
+alice.destroy('rabbit', '3-66c01cdf99e84c83a9b3fe65b88db8c0', function(err, body) {
   if (!err)
     console.log(body);
 });


### PR DESCRIPTION
Just a minor commit, so didn't make a branch.
