### PR TITLE
request_defaults should not be ignored

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -1065,7 +1065,7 @@ module.exports = exports = nano = function database_module(cfg) {
   // please send pull requests if you want to use a option
   // in request that is not exposed
   if(cfg.request_defaults) {
-    request = require('request').defaults(cfg.request_defaults);
+    cfg.request = require('request').defaults(cfg.request_defaults);
   }
 
   // assuming a cfg.log inside cfg


### PR DESCRIPTION
request wasn't put on cfg (used to be a global object as far as I can
tell but has been since changed) so it was always getting recreated in
relax() without using the request_defaults.

fix by attaching the original request created back on cfg.
