### PR TITLE
(#171) - multipart api

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ minimalistic couchdb driver for node.js
 	- [db.bulk(docs, [params], [callback])](#dbbulkdocs-params-callback)
 	- [db.list([params], [callback])](#dblistparams-callback)
 	- [db.fetch(docnames, [params], [callback])](#dbfetchdocnames-params-callback)
+- [multipart functions](#multipart-functions)
+	- [db.multipart.insert(doc, attachments, [params], [callback])](#dbmultipartinsertdoc-attachments-params-callback)
+	- [db.multipart.get(docname, [params], [callback])](#dbmultipartgetdocname-params-callback)
 - [attachments functions](#attachments-functions)
 	- [db.attachment.insert(docname, attname, att, contenttype, [params], [callback])](#dbattachmentinsertdocname-attname-att-contenttype-params-callback)
 	- [db.attachment.get(docname, attname, [params], [callback])](#dbattachmentgetdocname-attname-params-callback)
@@ -320,6 +323,7 @@ makes a request to couchdb, the available `opts` are:
 * `opts.headers` – additional http headers, overrides existing ones
 * `opts.body` – the document or attachment body
 * `opts.encoding` – the encoding for attachments
+* `opts.multipart` – array of objects for multipart request
 
 ### nano.relax(opts, [callback])
 
@@ -429,6 +433,41 @@ bulk fetch of the database documents, `docnames` are specified as per
 [couchdb doc](http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API).
 additional query string `params` can be specified, `include_docs` is always set
 to `true`.  
+
+## multipart functions
+
+### db.multipart.insert(doc, attachments, [params], [callback])
+
+inserts a `doc` together with `attachments` and optional `params`. if params is a string, its assumed as the intended document name. if params is an object, its passed as query string parameters and `doc_name` is checked for defining the document name.
+ refer to the [doc](http://wiki.apache.org/couchdb/HTTP_Document_API#Multiple_Attachments) for more details.
+ `attachments` must be an array of objects with `name`, `data` and `content_type` properties.
+
+``` js
+var fs = require('fs');
+
+fs.readFile('rabbit.png', function(err, data) {
+  if (!err) {
+    alice.multipart.insert({ foo: 'bar' }, [{name: 'rabbit.png', data: data, content_type: 'image/png'}], 'mydoc', function(err, body) {
+        if (!err)
+          console.log(body);
+    });
+  }
+});
+```
+
+### db.multipart.get(docname, [params], [callback])
+
+get `docname` together with its attachments via `multipart/related` request with optional query string additions
+`params`. refer to the
+ [doc](http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Attachments_With_a_Document) for more details.
+ the multipart response body is a `Buffer`.
+
+``` js
+alice.multipart.get('rabbit', function(err, buffer) {
+  if (!err)
+    console.log(buffer.toString());
+});
+```
 
 ## attachments functions
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "Andreas Lappe <nd@off-pist.de>",
     "Aram Kocharyan <akarmenia@gmail.com>",
     "Jan Krems @jkrems",
-    "Owen Evans <owen@bgeek.net> (http://www.bgeek.net)"
+    "Owen Evans <owen@bgeek.net> (http://www.bgeek.net)",
+    "Johannes J. Schmidt <schmidt@netzmerk.com> (http://die-tf.de)"
   ],
   "keywords": [
     "couchdb",

--- a/tests/fixtures/multipart/get.json
+++ b/tests/fixtures/multipart/get.json
@@ -1,0 +1,23 @@
+[
+  { "method"   : "put"
+  , "path"     : "/multipart_get"
+  , "status"   : 201
+  , "response" : "{ \"ok\": true }" 
+  }
+, { "method"   : "put"
+  , "path"     : "/multipart_get/foobaz"
+  , "body"     : "*"
+  , "status"   : 201
+  , "response" : "{\"ok\": true, \"id\": \"foobaz\", \"rev\": \"1-921bd51\" }"
+  }
+, { "path"     : "/multipart_get/foobaz?attachments=true"
+  , "status"   : 200
+  , "headers"  : { "content-type": "multipart\/related; boundary=\"33d91dba65f66463e14ac1ae75d79403\"" }
+  , "buffer"   : "LS0wN2ExNmJjYTNjYTA4MzA4YjQ4Njg3MjU3MDE1YjQ3YQ0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9qc29uDQoNCnsiX2lkIjoiZm9vYmF6IiwiX3JldiI6IjEtYzk0NjQ4MWI0MzI3NTc4ZTNmNDg4NmZiYzAwMjc3OTAiLCJmb28iOiJiYXoiLCJfYXR0YWNobWVudHMiOnsiYXR0Ijp7ImNvbnRlbnRfdHlwZSI6InRleHQvcGxhaW4iLCJyZXZwb3MiOjEsImRpZ2VzdCI6Im1kNS1qcmxBaXVQRmg5SFJCZmp5RHFqRlF3PT0iLCJsZW5ndGgiOjEyLCJmb2xsb3dzIjp0cnVlLCJlbmNvZGluZyI6Imd6aXAiLCJlbmNvZGVkX2xlbmd0aCI6MzJ9fX0NCi0tMDdhMTZiY2EzY2EwODMwOGI0ODY4NzI1NzAxNWI0N2ENCkNvbnRlbnQtRGlzcG9zaXRpb246IGF0dGFjaG1lbnQ7IGZpbGVuYW1lPSJhdHQiDQpDb250ZW50LVR5cGU6IHRleHQvcGxhaW4NCkNvbnRlbnQtTGVuZ3RoOiAzMg0KQ29udGVudC1FbmNvZGluZzogZ3ppcA0KDQofiwgAAAAAAAAD80jNyclXCM8vyklRBACjHCkcDAAAAA0KLS0wN2ExNmJjYTNjYTA4MzA4YjQ4Njg3MjU3MDE1YjQ3YS0t"
+  }
+, { "method"   : "delete"
+  , "path"     : "/multipart_get"
+  , "status"   : 200
+  , "response" : "{ \"ok\": true }" 
+  }
+]

--- a/tests/fixtures/multipart/insert.json
+++ b/tests/fixtures/multipart/insert.json
@@ -1,0 +1,18 @@
+[
+  { "method"   : "put"
+  , "path"     : "/multipart_insert"
+  , "status"   : 201
+  , "response" : "{ \"ok\": true }" 
+  }
+, { "method"   : "put"
+  , "path"     : "/multipart_insert/foobaz"
+  , "body"     : "*"
+  , "status"   : 201
+  , "response" : "{\"ok\": true, \"id\": \"foobaz\", \"rev\": \"1-921bd51\" }"
+  }
+, { "method"   : "delete"
+  , "path"     : "/multipart_insert"
+  , "status"   : 200
+  , "response" : "{ \"ok\": true }" 
+  }
+]

--- a/tests/multipart/get.js
+++ b/tests/multipart/get.js
@@ -1,0 +1,47 @@
+var specify    = require("specify")
+  , helpers    = require("../helpers")
+  , timeout    = helpers.timeout
+  , nano       = helpers.nano
+  , nock       = helpers.nock
+  ;
+
+var mock = nock(helpers.couch, "multipart/get")
+  , db   = nano.use("multipart_get")
+  , rev
+  ;
+
+specify("multipart_get:setup", timeout, function (assert) {
+  nano.db.create("multipart_get", function (err) {
+    assert.equal(err, undefined, "Failed to create database");
+    var att = {
+      name: 'att',
+      data: 'Hello World!',
+      content_type: 'text/plain'
+    };
+    db.multipart.insert({"foo": "baz"}, [att], "foobaz", function (error, foo) {
+      assert.equal(error, undefined, "Should have stored foobaz");
+      assert.equal(foo.ok, true, "Response should be ok");
+      assert.equal(foo.id, "foobaz", "My id is foobaz");
+      assert.ok(foo.rev, "Response should have rev");
+      rev = foo.rev;
+    });
+  });
+});
+
+specify("multipart_get:test", timeout, function (assert) {
+  db.multipart.get("foobaz", function (error, foobaz, headers) {
+    assert.equal(error, undefined, "Should get foobaz");
+    assert.ok(headers['content-type'].match(/^multipart\/related;/));
+    assert.equal(typeof foobaz, 'object', "foobaz should be a buffer");
+    assert.ok(true);
+  });
+});
+
+specify("multipart_get:teardown", timeout, function (assert) {
+  nano.db.destroy("multipart_get", function (err) {
+    assert.equal(err, undefined, "Failed to destroy database");
+    assert.ok(mock.isDone(), "Some mocks didn't run");
+  });
+});
+
+specify.run(process.argv.slice(2));

--- a/tests/multipart/insert.js
+++ b/tests/multipart/insert.js
@@ -1,0 +1,40 @@
+var specify  = require('specify')
+  , helpers  = require('../helpers')
+  , timeout  = helpers.timeout
+  , nano     = helpers.nano
+  , nock     = helpers.nock
+  , rev
+  ;
+
+var mock = nock(helpers.couch, "multipart/insert")
+  , db   = nano.use("multipart_insert")
+  ;
+
+specify("multipart_insert:setup", timeout, function (assert) {
+  nano.db.create("multipart_insert", function (err) {
+    assert.equal(err, undefined, "Failed to create database");
+  });
+});
+
+specify("multipart_insert:test", timeout, function (assert) {
+  var att = {
+    name: 'att',
+    data: 'Hello World!',
+    content_type: 'text/plain'
+  };
+  db.multipart.insert({"foo": "baz"}, [att], "foobaz", function (error, foo) {
+    rev = foo.rev;
+    assert.equal(error, undefined, "Should have stored foo and attachment");
+    assert.equal(foo.ok, true, "Response should be ok");
+    assert.ok(foo.rev, "Response should have rev");
+  });
+});
+
+specify("multipart_insert:teardown", timeout, function (assert) {
+  nano.db.destroy("multipart_insert", function (err) {
+    assert.equal(err, undefined, "Failed to destroy database");
+    assert.ok(mock.isDone(), "Some mocks didn't run");
+  });
+});
+
+specify.run(process.argv.slice(2));


### PR DESCRIPTION
Introduce `db.multipart` api endpoint for making multipart/related requests:

```
db.multipart.get(doc, attachments, [params], [callback])
db.multipart.insert(doc, attachments, [params], [callback])
```

Note: the `db.multipart.get` response is an unparsed `Buffer`.
