### PR TITLE
get session nock

### DIFF
--- a/tests/fixtures/shared/cookie.json
+++ b/tests/fixtures/shared/cookie.json
@@ -16,6 +16,12 @@
   , "status"   : 201
   , "response" : "{ \"ok\": true,\"name\": null,\"roles\": [ \"_admin\" ] }"
   }
+, { "method"   : "get"
+  , "path"     : "/_session"
+  , "headers"  : {"set-cookie" : ["AuthSession=YWRtaW46NEZCMzFERDk6BJyusEcy3SgfI9xD4Mptl0N0gh0;Version=1;Path=/;HttpOnly"]}
+  , "status"   : 201
+  , "response" : "{ \"ok\": true,\"userCtx\": {\"name\":\"admin\",\"roles\": [ \"_admin\" ]} }"
+  }
 , { "method"   : "post"
   , "status"   : 201
   , "path"     : "/shared_cookie"


### PR DESCRIPTION
add nock for GET _session, needed for the testsuite to pass.

btw this is based on top of #176 
