### PR TITLE
Added a badge for the dscape/nano room on gitter.im

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ where `list_doc_params` is the test name.
 * bugs: <http://github.com/dscape/nano/issues>
 * build: [![build status](https://secure.travis-ci.org/dscape/nano.png)](http://travis-ci.org/dscape/nano)
 * deps: [![deps status](https://david-dm.org/dscape/nano.png)](https://david-dm.org/dscape/nano)
-* support: <https://gitter.im/dscape/nano>
+* chat: <https://gitter.im/dscape/nano>
 
 `(oo)--',-` in [caos][3]
 


### PR DESCRIPTION
Added a badge and a link to https://gitter.im/dscape/nano.
