### PR TITLE
Upgrade request dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "database"
   ],
   "dependencies": {
-    "request": "~2.27.0",
+    "request": "~2.33.0",
     "follow": "~0.10.1",
     "errs": "~0.2.4",
     "underscore": "~1.5.1"


### PR DESCRIPTION
Request 2.27.0 has a bug that breaks debugging with NODE_DEBUG. This bug is fixed in 2.28.0 and later. See mikeal/request#659 for more info.
