### PR TITLE
Added fetch_revs method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ minimalistic couchdb driver for node.js
 	- [db.bulk(docs, [params], [callback])](#dbbulkdocs-params-callback)
 	- [db.list([params], [callback])](#dblistparams-callback)
 	- [db.fetch(docnames, [params], [callback])](#dbfetchdocnames-params-callback)
+  - [db.fetch_revs(docnames, [params], [callback])](#dbfetch_revsdocnames-params-callback)
 - [multipart functions](#multipart-functions)
 	- [db.multipart.insert(doc, attachments, [params], [callback])](#dbmultipartinsertdoc-attachments-params-callback)
 	- [db.multipart.get(docname, [params], [callback])](#dbmultipartgetdocname-params-callback)
@@ -434,6 +435,13 @@ bulk fetch of the database documents, `docnames` are specified as per
 additional query string `params` can be specified, `include_docs` is always set
 to `true`.
 
+### db.fetch_revs(docnames, [params], [callback])
+
+bulk fetch of the revisions of the database documents, `docnames` are specified as per
+[couchdb doc](http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API).
+additional query string `params` can be specified, this is the same method as fetch but
+ `include_docs` is not automatically set to `true`.
+
 ## multipart functions
 
 ### db.multipart.insert(doc, attachments, [params], [callback])
@@ -593,7 +601,7 @@ db.atomic("update", "inplace", "foobar",
 });
 ```
 
-Note that the data is sent in the body of the request.  
+Note that the data is sent in the body of the request.
 An example update handler follows:
 
 ``` js

--- a/nano.js
+++ b/nano.js
@@ -776,6 +776,27 @@ module.exports = exports = nano = function database_module(cfg) {
     }
 
    /*
+    * bulk fetch functionality for doc revisions
+    * [1]: http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API
+    * same as fetch_docs but without include_docs set to true
+    *
+    * @param {doc_names:object} document keys as per the couchdb api[1]
+    * @param {params:object} additions to the querystring
+    *
+    * @see get_doc
+    * @see relax
+    */
+    function fetch_revs(doc_names,params,callback) {
+      if(typeof params === 'function') {
+        callback = params;
+        params   = {};
+      }
+      return relax(
+        { db: db_name, path: '_all_docs', method: 'POST'
+        , params: params, body: doc_names }, callback);
+    }
+    
+   /*
     * calls a view
     *
     * @param {design_name:string} design document name
@@ -1109,6 +1130,7 @@ module.exports = exports = nano = function database_module(cfg) {
       , bulk              : bulk_docs
       , list              : list_docs
       , fetch             : fetch_docs
+      , fetch_revs        : fetch_revs
       , config            : {url: cfg.url, db: db_name}
       , multipart         :
         { insert          : insert_multipart

--- a/tests/doc/fetch_revs.js
+++ b/tests/doc/fetch_revs.js
@@ -1,0 +1,53 @@
+var specify  = require('specify')
+  , async    = require('async')
+  , helpers  = require('../helpers')
+  , timeout  = helpers.timeout
+  , nano     = helpers.nano
+  , nock     = helpers.nock
+  ;
+
+var mock = nock(helpers.couch, "doc/fetch_revs")
+  , db   = nano.use("doc_fetch_revs")
+  ;
+
+specify("doc_fetch_revs:setup", timeout, function (assert) {
+  nano.db.create("doc_fetch_revs", function (err) {
+    assert.equal(err, undefined, "Failed to create database");
+    async.parallel(
+      [ function(cb) { db.insert({"foo": "bar"}, "foobar", cb); }
+      , function(cb) { db.insert({"bar": "foo"}, "barfoo", cb); }
+      , function(cb) { db.insert({"foo": "baz"}, "foobaz", cb); }
+      ]
+    , function(error, results) {
+      assert.equal(error, undefined, "Should have stored docs");
+    });
+  });
+});
+
+specify("doc_fetch_revs:one_key", timeout, function (assert) {
+  db.fetch_revs({keys:["foobar"]}, function (error, docs) {
+    assert.equal(error, undefined, 'No errors');
+    assert.equal(docs.rows.length, 1, 'One row');
+    assert.equal(docs.total_rows, 3, 'Out of 3');
+    assert.equal(docs.rows[0].doc, undefined, 'No doc');
+  });
+});
+
+specify("doc_fetch_revs:multiple_keys", timeout, function (assert) {
+  db.fetch_revs({keys:["foobar", "barfoo"]}, function (error, docs) {
+    assert.equal(error, undefined, 'No errors');
+    assert.equal(docs.rows.length, 2, 'Two rows');
+    assert.equal(docs.total_rows, 3, 'Out of 3');
+    assert.equal(docs.rows[0].doc, undefined, 'No doc');
+    assert.equal(docs.rows[1].doc, undefined, 'No doc');
+  });
+});
+
+specify("doc_fetch_revs:teardown", timeout, function (assert) {
+  nano.db.destroy("doc_fetch_revs", function (err) {
+    assert.equal(err, undefined, "Failed to destroy database");
+    assert.ok(mock.isDone(), "Some mocks didn't run");
+  });
+});
+
+specify.run(process.argv.slice(2));

--- a/tests/fixtures/doc/fetch_revs.json
+++ b/tests/fixtures/doc/fetch_revs.json
@@ -1,0 +1,40 @@
+[
+  { "method"   : "put"
+  , "path"     : "/doc_fetch_revs"
+  , "status"   : 201
+  , "response" : "{ \"ok\": true }"
+  }
+, { "method"   : "put"
+  , "status"   : 201
+  , "path"     : "/doc_fetch_revs/foobar"
+  , "body"     : "{\"foo\":\"bar\"}"
+  , "response" : "{\"ok\":true,\"id\":\"foobar\",\"rev\":\"1-4c6114\"}"
+  }
+, { "method"   : "put"
+  , "status"   : 201
+  , "path"     : "/doc_fetch_revs/foobaz"
+  , "body"     : "{\"foo\":\"baz\"}"
+  , "response" : "{\"ok\":true,\"id\":\"foobaz\",\"rev\":\"1-611488\"}"
+  }
+, { "method"   : "put"
+  , "status"   : 201
+  , "path"     : "/doc_fetch_revs/barfoo"
+  , "body"     : "{\"bar\":\"foo\"}"
+  , "response" : "{\"ok\":true,\"id\":\"barfoo\",\"rev\":\"1-3cde10\"}"
+  }
+, { "method"   : "post"
+  , "path"     : "/doc_fetch_revs/_all_docs"
+  , "body"     : "{\"keys\":[\"foobar\"]}"
+  , "response" : "{\"total_rows\":3,\"offset\":0,\"rows\":[\r\n{\"id\":\"foobar\",\"key\":\"foobar\",\"value\":{\"rev\":\"1-4c6114c65e295552ab1019e2b046b10e\"}}\r\n]}\n"
+  }
+, { "method"   : "post"
+  , "path"     : "/doc_fetch_revs/_all_docs"
+  , "body"     : "{\"keys\":[\"foobar\",\"barfoo\"]}"
+  , "response" : "{\"total_rows\":3,\"offset\":0,\"rows\":[\r\n{\"id\":\"foobar\",\"key\":\"foobar\",\"value\":{\"rev\":\"1-4c6114c65e295552ab1019e2b046b10e\"}},\r\n{\"id\":\"barfoo\",\"key\":\"barfoo\",\"value\":{\"rev\":\"1-41412c293dade3fe73279cba8b4cece4\"}}\r\n]}\n"
+  }
+, { "method"   : "delete"
+  , "path"     : "/doc_fetch_revs"
+  , "status"   : 200
+  , "response" : "{ \"ok\": true }"
+  }
+]


### PR DESCRIPTION
I saw myself forced to add `fetch_revs` method to avoid pulling all the docs when I only needed the revisions. This saves memory (no docs occupying memory while working with revs), improves performance (I'm using Cloudant so waiting for all the docs to download is slower than waiting just for revs) and saves bandwidth (not relevant for me but could be for those running apps that have metered bandwidth)
