### PR TITLE
Don't JSON stringify or parse attachments

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -221,7 +221,7 @@ module.exports = exports = nano = function database_module(cfg) {
     }
 
     if(opts.body) {
-      if (Buffer.isBuffer(opts.body)) {
+      if (Buffer.isBuffer(opts.body) || opts.dont_stringify) {
         req.body = opts.body; // raw data
       }
       else {
@@ -292,7 +292,11 @@ module.exports = exports = nano = function database_module(cfg) {
         delete rh.server;
         delete rh['content-length'];
 
-        try { parsed = JSON.parse(b); } catch (err) { parsed = b; }
+        if (opts.dont_parse) {
+          parsed = b;
+        } else {
+          try { parsed = JSON.parse(b); } catch (err) { parsed = b; }
+        }
 
         if (status_code >= 200 && status_code < 400) {
           log({err: null, body: parsed, headers: rh});
@@ -1014,7 +1018,7 @@ module.exports = exports = nano = function database_module(cfg) {
       return relax(
         { db: db_name, att: att_name, method: 'PUT'
         , content_type: content_type, doc: doc_name, params: params
-        , body: att}, callback);
+        , body: att, dont_stringify: true}, callback);
     }
 
    /*
@@ -1032,7 +1036,7 @@ module.exports = exports = nano = function database_module(cfg) {
         params   = {};
       }
       return relax({ db: db_name, att: att_name, method: 'GET', doc: doc_name
-                   , params: params, encoding: null},callback);
+                   , params: params, encoding: null, dont_parse: true},callback);
     }
 
    /*

--- a/tests/att/get.js
+++ b/tests/att/get.js
@@ -16,16 +16,30 @@ specify("att_get:setup", timeout, function (assert) {
   });
 });
 
-specify("att_get:test", timeout, function (assert) {
-  db.attachment.insert("new", "att", "Hello", "text/plain", 
+specify("att_get:test_string", timeout, function (assert) {
+  db.attachment.insert("new_string", "att", "Hello", "text/plain", 
   function(error, hello) {
     assert.equal(error, undefined, "Should store hello");
     assert.equal(hello.ok, true, "Response should be ok");
     assert.ok(hello.rev, "Should have a revision number");
-    db.attachment.get("new", "att", 
+    db.attachment.get("new_string", "att", 
     function (error, helloWorld) {
       assert.equal(error, undefined, "Should get the hello");
-      assert.equal("Hello", helloWorld, "hello is reflexive");
+      assert.equal("Hello", helloWorld, "string is reflexive");
+    });
+  });
+});
+
+specify("att_get:test_binary", timeout, function (assert) {
+  db.attachment.insert("new_binary", "att", new Buffer("123"), "text/plain", 
+  function(error, hello) {
+    assert.equal(error, undefined, "Should store 123");
+    assert.equal(hello.ok, true, "Response should be ok");
+    assert.ok(hello.rev, "Should have a revision number");
+    db.attachment.get("new_binary", "att", 
+    function (error, binaryData) {
+      assert.equal(error, undefined, "Should get the binary data");
+      assert.equal("123", binaryData, "binary data is reflexive");
     });
   });
 });

--- a/tests/fixtures/att/destroy.json
+++ b/tests/fixtures/att/destroy.json
@@ -6,7 +6,7 @@
   }
 , { "method"   : "put"
   , "path"     : "/att_destroy/new/att"
-  , "body"     : "\"Hello World!\""
+  , "body"     : "Hello World!"
   , "status"   : 201
   , "response" : "{\"ok\": true, \"id\": \"new\", \"rev\": \"1-921bd51\" }"
   }
@@ -17,7 +17,7 @@
   }
 , { "method"   : "put"
   , "path"     : "/att_destroy/new2/att2"
-  , "body"     : "\"Hello World!\""
+  , "body"     : "Hello World!"
   , "status"   : 201
   , "response" : "{\"ok\": true, \"id\": \"new\", \"rev\": \"1-921bd51\" }"
   }

--- a/tests/fixtures/att/get.json
+++ b/tests/fixtures/att/get.json
@@ -5,14 +5,24 @@
   , "response" : "{ \"ok\": true }" 
   }
 , { "method"   : "put"
-  , "path"     : "/att_get/new/att"
-  , "body"     : "\"Hello\""
+  , "path"     : "/att_get/new_string/att"
+  , "body"     : "Hello"
   , "status"   : 201
-  , "response" : "{\"ok\":true,\"id\":\"new\",\"rev\":\"1-5142a2\"}"
+  , "response" : "{\"ok\":true,\"id\":\"new_string\",\"rev\":\"1-5142a2\"}"
   }
-, { "path"     : "/att_get/new/att"
+, { "path"     : "/att_get/new_string/att"
   , "status"   : 200
-  , "response" : "\"Hello\""
+  , "response" : "Hello"
+  }
+, { "method"   : "put"
+  , "path"     : "/att_get/new_binary/att"
+  , "base64"   : "MTIz"
+  , "status"   : 201
+  , "response" : "{\"ok\":true,\"id\":\"new_binary\",\"rev\":\"1-5142ff\"}"
+  }
+, { "path"     : "/att_get/new_binary/att"
+  , "status"   : 200
+  , "buffer"   : "MTIz"
   }
 , { "method"   : "delete"
   , "path"     : "/att_get"

--- a/tests/fixtures/att/insert.json
+++ b/tests/fixtures/att/insert.json
@@ -6,7 +6,7 @@
   }
 , { "method"   : "put"
   , "path"     : "/att_insert/new/att"
-  , "body"     : "\"Hello World!\""
+  , "body"     : "Hello World!"
   , "status"   : 201
   , "response" : "{\"ok\": true, \"id\": \"new\", \"rev\": \"1-921bd51\" }"
   }

--- a/tests/fixtures/att/update.json
+++ b/tests/fixtures/att/update.json
@@ -6,7 +6,7 @@
   }
 , { "method"   : "put"
   , "path"     : "/att_update/new/att"
-  , "body"     : "\"Hello\""
+  , "body"     : "Hello"
   , "status"   : 201
   , "response" : "{\"ok\":true,\"id\":\"new\",\"rev\":\"1-5142a2\"}"
   }

--- a/tests/fixtures/shared/headers.json
+++ b/tests/fixtures/shared/headers.json
@@ -6,7 +6,7 @@
   }
 , { "method"   : "put"
   , "path"     : "/shared_headers/new/att"
-  , "body"     : "\"Hello\""
+  , "body"     : "Hello"
   , "status"   : 201
   , "response" : "{\"ok\":true,\"id\":\"new\",\"rev\":\"1-5142a2\"}"
   }


### PR DESCRIPTION
Ok here's the first chunk of the PR for review.

I've added a test that ensures that binary data that is parseble as JSON will not be parsed, and also updated the fixtures for the other attachment tests.

There are two internal options, dont_stringify and dont_parse that are used by attachment insert and get respectively. 

I'll update the PR with the README changes if you think the approach is good. For the README I was thinking of adding these options to the described options, and describe the changes in the "attachment" section.
