### PR TITLE
Updated piped attachment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,11 @@ or using `pipe`:
 var fs = require('fs');
 
 fs.createReadStream('rabbit.png').pipe(
-    alice.attachment.insert('new', 'rab.png', null, 'image/png')
+    alice.attachment.insert('rabbit', 'rabbit.png', null, 'image/png',
+      { rev: '12-150985a725ec88be471921a54ce91452' }, function(err, body) {
+        if (!err)
+          console.log(body);
+    })
 );
 ```
 


### PR DESCRIPTION
The docs didn't include passing the document revision or callback function in the piped attachment example.

If you're copy/pasting the examples, plugging values in and expecting it to work and/or be notified when something fails it's rather difficult without them!
