### PR TITLE
Compatibility with auth credentials contains symbols that must be url en...

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -1235,7 +1235,15 @@ module.exports = exports = nano = function database_module(cfg) {
   //   should return a nano object
   if (path.pathname && path_array.length > 0) {
 
-    auth    = path.auth ? path.auth + '@' : '';
+    auth = '';
+    if(path.auth) {
+        var parts = path.auth.split(':');
+        for(var i=0; i<parts.length; i++)
+            parts[i] = encodeURIComponent(parts[i]);
+
+        auth = parts.join(':') + '@';
+    }
+
     port    = path.port ? ':' + path.port : '';
     db      = cfg.db ? cfg.db : path_array[0];
 

--- a/tests/shared/config.js
+++ b/tests/shared/config.js
@@ -36,6 +36,13 @@ specify("shared_config:url_parsing", timeout, function (assert) {
     Nano(base_url+'/a').config.url, base_url, "Simple db failed");
 });
 
+specify("shared_config:url_resolving", timeout, function (assert) {
+    var dbName = "a";
+    var confUrl = Nano('http://a%40%3F%2F%20%23%26:b%40%3F%2F%20%23%26@someurl.com:5984/' + dbName).config.url;
+    var resolvedUrl = require("url").resolve(confUrl, encodeURIComponent(dbName));
+    assert.equal(confUrl + "/" + dbName, resolvedUrl, "Url must remain correct after require(\"url\").resolve");
+});
+
 specify("shared_config:default_headers", timeout, function (assert) {
   var nanoWithDefaultHeaders = Nano(
   { url: couch


### PR DESCRIPTION
...coded + test
(please close my recent pull request)

The bug is:

If you don’t do encoding in configuration, then in function relax(opts,callback) row 127:
req.uri = u.resolve(req.uri, encodeURIComponent(opts.db));

req.uri became incorrect.

I have added test to check if resolved by require("url").resolve() url remain correct: "shared_config:url_resolving"
