### PR TITLE
Please upgrade mikeal/request to v2.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "database"
   ],
   "dependencies": {
-    "request": "~2.33.0",
+    "request": "~2.40.0",
     "follow": "~0.11.2",
     "errs": "~0.2.4",
     "underscore": "~1.5.1"


### PR DESCRIPTION
This fixes an issue with SSL proxying in node v0.11.

Fixes https://github.com/dscape/nano/issues/217
