### PR TITLE
Fix multipart inserts of attachments containing unicode chars.

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -1012,7 +1012,7 @@ module.exports = exports = nano = function database_module(cfg) {
       attachments.forEach(function(att) {
         doc._attachments[att.name] = {
           follows: true,
-          length: att.data.length,
+          length: Buffer.byteLength(att.data),
           content_type: att.content_type
         };
       });

--- a/tests/fixtures/multipart/insert.json
+++ b/tests/fixtures/multipart/insert.json
@@ -11,6 +11,12 @@
   , "response" : "{\"ok\": true, \"id\": \"foobaz\", \"rev\": \"1-921bd51\" }"
   }
 , { "method"   : "put"
+  , "path"     : "/multipart_insert/foobar"
+  , "body"     : "*"
+  , "status"   : 201
+  , "response" : "{\"ok\": true, \"id\": \"foobar\", \"rev\": \"1-921bd51\" }"
+  }
+, { "method"   : "put"
   , "path"     : "/multipart_insert/mydoc/one"
   , "body"     : "Hello World!"
   , "status"   : 201

--- a/tests/multipart/insert.js
+++ b/tests/multipart/insert.js
@@ -28,6 +28,19 @@ specify("multipart_insert:test", timeout, function (assert) {
   });
 });
 
+specify("multipart_insert:test_with_attachment_containing_unicode_characters", timeout, function (assert) {
+  var att = {
+    name: 'att',
+    data: 'काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥',
+    content_type: 'text/plain'
+  };
+  db.multipart.insert({"foo": "bar"}, [att], "foobar", function (error, foo) {
+    assert.equal(error, undefined, "Should have stored foo and attachment");
+    assert.equal(foo.ok, true, "Response should be ok");
+    assert.ok(foo.rev, "Response should have rev");
+  });
+});
+
 specify("multipart_insert:test_with_present_attachment", timeout, function (assert) {
   var att = {
     name: 'two',


### PR DESCRIPTION
Previously, couchdb would throw an error when attempting to do multipart
inserts of attachments containing unicode characters. This was caused by
the Content-Length header being incorrectly set to the number of
characters of the attachment (via `data.length`) rather than the number
of bytes (using `Buffer.byteLength(data)`).
