### PR TITLE
Fix encoded basic auth values being decoded

### DIFF
--- a/nano.js
+++ b/nano.js
@@ -1282,14 +1282,16 @@ module.exports = exports = nano = function database_module(cfg) {
   //   should return a nano object
   if (path.pathname && path_array.length > 0) {
 
-    auth    = path.auth ? path.auth + '@' : '';
+    auth    = path.auth ? path.auth : '';
     port    = path.port ? ':' + path.port : '';
     db      = cfg.db ? cfg.db : decodeURIComponent(path_array[0]);
 
     var format = {
       protocol: path.protocol,
-      host: auth + path.hostname + port
+      host: path.hostname + port
     };
+    if(auth)
+      format.auth = auth;
     if (cfg.db)
       format.pathname = path.pathname + '/';
 

--- a/tests/shared/config.js
+++ b/tests/shared/config.js
@@ -30,6 +30,9 @@ specify("shared_config:url_parsing", timeout, function (assert) {
     Nano('http://a:b@someurl.com:5984').config.url,
     'http://a:b@someurl.com:5984', "Auth failed");
   assert.equal(
+    Nano('http://a:b%20c%3F@someurl.com:5984/mydb').config.url,
+    'http://a:b%20c%3F@someurl.com:5984', "Database escaped auth failed");
+  assert.equal(
     Nano(base_url+':5984/a').config.url, base_url+':5984',
     "Port failed");
   assert.equal(


### PR DESCRIPTION
When a database was specified in the URL as a path component, the basic auth would get decoded and never reencoded. This would cause future operations to fail as the url parsing would come against characters invalid in a URL.
