### PR TITLE
Check docName parameter to avoid db delete

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -353,12 +353,19 @@ module.exports = exports = nano = function dbScope(cfg) {
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
     function destroyDoc(docName, rev, callback) {
-      return relax({
-        db: dbName,
-        doc: docName,
-        method: 'DELETE',
-        qs: {rev: rev}
-      }, callback);
+      //Test if a user provides a docname to avoid deleting a db
+      if(!docName) {
+        if(callback)
+          callback("You must specify a doc name", null);
+      }
+      else {
+        return relax({
+          db: dbName,
+          doc: docName,
+          method: 'DELETE',
+          qs: {rev: rev}
+        }, callback);  
+      }
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#get--db-docid


### PR DESCRIPTION
Passing null/undefined into docname resulted in db deletion due to the way the url gets constructed