### PR TITLE
fixed content_type mistake in insertMultipart

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -554,7 +554,7 @@ module.exports = exports = nano = function dbScope(cfg) {
           follows: true,
           length: Buffer.isBuffer(att.data) ?
             att.data.length : Buffer.byteLength(att.data),
-          'content_type': att.contentType
+          'content_type': att.content_type
         };
         multipart.push({body: att.data});
       });


### PR DESCRIPTION
The previous code was looking for the wrong property name (contentType) in the attachments array in insertMultipart. It should be content_type.