### PR TITLE
Introduce parseUrl flag to prevent db extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,18 @@ var db = require('nano')(
 ```
 Please check [request] for more information on the defaults. They support features like cookie jar, proxies, ssl, etc.
 
+You can tell nano to not parse the url (maybe the server is behind a proxy, is accessed through a rewrite rule or other):
+
+```js
+// nano does not parse the url and return the server api
+// "http://localhost:5984/prefix" is the CouchDB server root
+var couch = require('nano')(
+  { "url"      : "http://localhost:5984/prefix"
+    "parseUrl" : false
+  });
+var db = couch.use('foo')
+```
+
 ### pool size and open sockets
 
 a very important configuration parameter if you have a high traffic website and are using nano is setting up the `pool.size`. by default, the node.js http global agent (client) has a certain size of active connections that can run simultaneously, while others are kept in a queue. pooling can be disabled by setting the `agent` property in `requestDefaults` to false, or adjust the global pool size using:

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -31,6 +31,23 @@ module.exports = exports = nano = function dbScope(cfg) {
     request.defaults(cfg.requestDefaults);
   var followAgent = (typeof cfg.follow === 'function') ? cfg.follow : follow;
   var log = typeof cfg.log === 'function' ? cfg.log : logger(cfg);
+  var parseUrl = 'parseUrl' in cfg ? cfg.parseUrl : true;
+
+  function maybeExtractDatabaseComponent() {
+    if (!parseUrl) {
+      return;
+    }
+
+    var path = u.parse(cfg.url);
+    var pathArray = path.pathname.split('/').filter(function(e) { return e; });
+    var db = pathArray.pop();
+    var rootPath = path.pathname.replace(/\/?$/, '/..');
+
+    if (db) {
+      cfg.url = u.resolve(cfg.url, rootPath).replace(/\/?$/, '');
+      return db;
+    }
+  }
 
   function relax(opts, callback) {
     if (typeof opts === 'function') {
@@ -716,17 +733,9 @@ module.exports = exports = nano = function dbScope(cfg) {
     followUpdates: followUpdates
   });
 
-  var path = u.parse(cfg.url);
-  var pathArray = path.pathname.split('/').filter(function(e) { return e; });
-  var db = pathArray.pop();
-  var rootPath = path.pathname.replace(/\/?$/, '/..');
+  var db = maybeExtractDatabaseComponent();
 
-  if (db) {
-    cfg.url = u.resolve(cfg.url, rootPath).replace(/\/?$/, '');
-    return docModule(db);
-  }
-
-  return serverScope;
+  return db ? docModule(db) : serverScope;
 };
 
 /*

--- a/tests/integration/shared/config.js
+++ b/tests/integration/shared/config.js
@@ -77,6 +77,20 @@ it('should be able to parse urls', function(assert) {
   assert.end();
 });
 
+it('should not parse urls when parseURL flag set to false', function(assert) {
+  var url = 'http://someurl.com/path';
+
+  assert.equal(
+    Nano({
+      url: url,
+      parseUrl: false
+    }).config.url,
+    url,
+    'the untouched url');
+
+  assert.end();
+});
+
 it('should accept and handle customer http headers', function(assert) {
   var nanoWithDefaultHeaders = Nano({
     url: helpers.couch,


### PR DESCRIPTION
When the `parseUrl` flag is set to `false` (default it `true`) `url` will not
be parsed but will be considered the root of the CouchDB server and Nanos
server api gets returned.