### PR TITLE
(fixes #253) - update follow

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "request": "2.46.0",
-    "follow": "^0.11.3",
+    "follow": "^0.11.4",
     "errs": "^0.3.0",
     "underscore": "^1.7.0",
     "debug": "^2.0.0"


### PR DESCRIPTION
Update follow from 0.11.3 to 0.11.4.
This closes a qs vulnerability in request versions before 2.40.0.