### PR TITLE
Insert's document name param property is docName

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ process.nextTick(function () {
 
 ### db.insert(doc, [params], [callback])
 
-inserts `doc` in the database with  optional `params`. if params is a string, its assumed as the intended document name. if params is an object, its passed as query string parameters and `doc_name` is checked for defining the document name.
+inserts `doc` in the database with  optional `params`. if params is a string, its assumed as the intended document name. if params is an object, its passed as query string parameters and `docName` is checked for defining the document name.
 
 ``` js
 var alice = nano.use('alice');


### PR DESCRIPTION
Either this or the nano.js library should be changed. Since I'm assuming other people are using the "docName" parameter, it's probably easier to update the documentation. It gets turned into "doc" in the actual params, so it doesn't align directly with couch either way.