### PR TITLE
Updating license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nano",
   "description": "minimalistic couchdb driver for node.js",
-  "license": "apache 2.0",
+  "license": "Apache-2.0",
   "homepage": "http://github.com/dscape/nano",
   "repository": "git://github.com/dscape/nano",
   "version": "6.1.2",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

Updated to "Apache-2.0" per https://spdx.org/licenses/