### PR TITLE
bumping branches coverage to 100% after #268

### DIFF
--- a/tests/integration/database/get.js
+++ b/tests/integration/database/get.js
@@ -25,3 +25,21 @@ it('should be able to fetch the database', function(assert) {
     assert.end();
   });
 });
+
+it('resolves db URL correctly for http://app.com/_couchdb', function(assert) {
+  var nano = require('../../../lib/nano');
+
+  var couch = nano({
+    url: 'http://app.com/_couchdb/',
+    parseUrl: false,
+    request: function(options) {
+      assert.equal(
+        options.uri,
+        'http://app.com/_couchdb/mydb/mydoc',
+        'should get doc at prefixed path'
+      );
+      assert.end();
+    }
+  });
+  couch.use('mydb').get('mydoc');
+});


### PR DESCRIPTION
The test doesn't follow the conventions of the other tests, I didn't know how to make it fit best. Feel free to refactor the way you want it :) But coverage is back at 100%. And I'd very much appreciate if you could release it, because we use nano in lots of projects where CouchDB does not live at the root of a domain, but is prefixed by `/_couchdb`