### PR TITLE
bumped follow to version 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "request": "^2.53.0",
-    "follow": "^0.11.4",
+    "follow": "^0.12.1",
     "errs": "^0.3.0",
     "underscore": "^1.7.0",
     "debug": "^2.0.0"


### PR DESCRIPTION
I noticed I got an npm warning whenever I installed Nano, because it's dependency (follow) didn't have the 0.12.x Node.js in its list of supported versions. It turned out that follow was up to 0.12.1, so this pull request just bumps the version up to that level. All the tests seem to pass.