### PR TITLE
Streamable multipart attachments

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -579,8 +579,8 @@ module.exports = exports = nano = function dbScope(cfg) {
         doc._attachments[att.name] = {
           follows: true,
           length: att.length ||
-            Buffer.isBuffer(att.data) ?
-            att.data.length : Buffer.byteLength(att.data),
+            ( Buffer.isBuffer(att.data) ?
+              att.data.length : Buffer.byteLength(att.data) ),
           /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
           'content_type': att.content_type
         };

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -578,7 +578,8 @@ module.exports = exports = nano = function dbScope(cfg) {
       attachments.forEach(function(att) {
         doc._attachments[att.name] = {
           follows: true,
-          length: Buffer.isBuffer(att.data) ?
+          length: att.length ||
+            Buffer.isBuffer(att.data) ?
             att.data.length : Buffer.byteLength(att.data),
           /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
           'content_type': att.content_type

--- a/tests/integration/multipart/insert.js
+++ b/tests/integration/multipart/insert.js
@@ -87,7 +87,7 @@ it('should work with attachment as a stream, when length is specified', function
     'content_type': 'text/plain'
   };
 
-  db.multipart.insert({'foo': 'bar'}, [att], 'alphabet', function(error, foo) {
+  db.multipart.insert({'foo': 'bar'}, [att], 'otherdoc', function(error, foo) {
     assert.equal(error, null, 'Should have stored foo and attachment');
     assert.equal(foo.ok, true, 'Response should be ok');
     assert.ok(foo.rev, 'Response should have rev');

--- a/tests/integration/multipart/insert.js
+++ b/tests/integration/multipart/insert.js
@@ -67,3 +67,32 @@ it('should work with attachment as a buffer', function(assert) {
     assert.end();
   });
 });
+
+it('should work with attachment as a stream, when length is specified', function (assert) {
+  var Readable = require('stream').Readable;
+  var rs = Readable();
+
+  var c = 'a'.charCodeAt(0);
+  rs._read = function () {
+      // this stream emits alphabet (abcde...xyz) one character at a time
+      // stolen from: https://github.com/substack/stream-handbook
+      rs.push(String.fromCharCode(c++));
+      if (c > 'z'.charCodeAt(0)) rs.push(null);
+  };
+
+  var att = {
+    name: 'att',
+    data: rs,
+    length: 26, // 'z'.charCodeAt(0) - 'a'.charCodeAt(0) + 1;
+    'content_type': 'text/plain'
+  };
+
+  db.multipart.insert({'foo': 'bar'}, [att], 'alphabet', function(error, foo) {
+    assert.equal(error, null, 'Should have stored foo and attachment');
+    assert.equal(foo.ok, true, 'Response should be ok');
+    assert.ok(foo.rev, 'Response should have rev');
+    assert.end();
+  });
+});
+
+// TODO it('should fail early with attachment as a stream, when length is NOT specified')


### PR DESCRIPTION
This is all it takes, really!

Tests are soon to `{ follow: true }`.
