### PR TITLE
body should be optional in db.atomic(design, updater, id, [body], [callback])

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -556,6 +556,10 @@ module.exports = exports = nano = function dbScope(cfg) {
 
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
     function updateWithHandler(ddoc, viewName, docName, body, callback) {
+      if (typeof body === 'function') {
+          callback = body;
+          body = undefined;
+      }
       return view(ddoc, viewName + '/' + encodeURIComponent(docName), {
         type: 'update',
         method: 'PUT',

--- a/tests/fixtures/design/atomic.json
+++ b/tests/fixtures/design/atomic.json
@@ -22,6 +22,10 @@
   , "response" : "{\"foo\": \"bar\"}"
   }
 , { "method"   : "put"
+  , "path"     : "/design_atomic/_design/update/_update/addbaz/baz"
+  , "response" : "{\"baz\": \"biz\"}"
+  }
+, { "method"   : "put"
   , "status"   : 201
   , "path"     : "/design_atomic/wat%2Fwat"
   , "body"     : "{\"wat\":\"wat\"}"

--- a/tests/integration/design/atomic.js
+++ b/tests/integration/design/atomic.js
@@ -26,6 +26,10 @@ it('should be able to insert an atomic design doc', function(assert) {
         var body = JSON.parse(req.body);
         doc[body.field] = body.value;
         return [doc, JSON.stringify(doc)];
+      },
+      addbaz: function (doc, req) {
+        doc.baz = "biz";
+        return [doc, JSON.stringify(doc)];
       }
     }
   }, '_design/update', function(err) {
@@ -48,6 +52,16 @@ it('should be able to insert atomically', function(assert) {
     assert.equal(error, null, 'should be able to update');
     assert.equal(response.foo, 'bar', 'and the right value was set');
     assert.end();
+  });
+});
+
+it('should be able to update atomically without a body', function (assert) {
+  db.insert({}, 'baz', function (error, doc) {
+    db.atomic('update', 'addbaz', 'baz', function (error, response) {
+      assert.equal(error, null, 'should be able to update');
+      assert.equal(response.baz, 'biz', 'and the new field is present');
+      assert.end();
+    });
   });
 });
 


### PR DESCRIPTION
The docs for `[db.atomic()](https://github.com/dscape/nano#dbatomicdesignname-updatename-docname-body-callback)` list the `body` parameter as optional, but running with only three parameters results in the following error:

```
TypeError: Cannot use 'in' operator to search for 'counts' in undefined
    at ~/work/nano/lib/nano.js:9:23066
    at Array.forEach (native)
    at view (~/work/nano/lib/nano.js:9:22951)
    at Object.updateWithHandler (~/work/nano/lib/nano.js:9:25070)
    at ~/work/nano/tests/integration/design/atomic.js:60:8
    at Request._callback (~/work/nano/lib/nano.js:9:11574)
    at Request.self.callback (~/work/nano/node_modules/request/request.js:200:22)
    at emitTwo (events.js:100:13)
    at Request.emit (events.js:185:7)
    at Request.<anonymous> (~/work/nano/node_modules/request/request.js:1067:10)
```

See enclosed patch.  I think I got the tests right, but please let me know if I missed anything.