### PR TITLE
Validate docName parameter to avoid db delete

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -393,12 +393,18 @@ module.exports = exports = nano = function dbScope(cfg) {
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
     function destroyDoc(docName, rev, callback) {
-      return relax({
-        db: dbName,
-        doc: docName,
-        method: 'DELETE',
-        qs: {rev: rev}
-      }, callback);
+      if(!docName) {
+        if(callback)
+          callback("Invalid doc id", null);
+      }
+      else {
+        return relax({
+          db: dbName,
+          doc: docName,
+          method: 'DELETE',
+          qs: {rev: rev}
+        }, callback);
+      }
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#get--db-docid

--- a/tests/integration/document/destroy.js
+++ b/tests/integration/document/destroy.js
@@ -29,6 +29,14 @@ it('should insert a document', function(assert) {
   });
 });
 
+it('should not delete a db', function(assert) {
+  db.destroy(undefined, undefined, function(error, response) {
+    assert.equal(error, 'Invalid doc id', 'validated delete parameters');
+    assert.equal(response, null, 'ok!');
+    assert.end();
+  });
+});
+
 it('should delete a document', function(assert) {
   db.destroy('foobaz', rev, function(error, response) {
     assert.equal(error, null, 'deleted foo');


### PR DESCRIPTION
Using the document destroy api it's currently possible if doc id and rev is null/undefined to delete the db.   Couchdb handles the case where doc is null but a rev id is passed in and the case where doc is passed in but no rev, however nothing protects you on couchdb when both those parameters are undefined.