### PR TITLE
fix: followDb() uses cfg.defaultHeaders

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -330,7 +330,9 @@ module.exports = exports = nano = function dbScope(cfg) {
       callback = qs;
       qs = {};
     }
-
+    
+    qs = qs || {};
+    qs.headers = _.extend(cfg.defaultHeaders, qs.headers);
     qs.db = urlResolveFix(cfg.url, encodeURIComponent(dbName));
 
     if (typeof callback === 'function') {


### PR DESCRIPTION
Now defaultHeaders are passed to followUpdates() and followDb() methods.
It can be useful if you use basic authorization
