### PR TITLE
Update express.js example for nano 6 and express 4

### DIFF
--- a/examples/express.js
+++ b/examples/express.js
@@ -12,16 +12,19 @@
 
 var express = require('express')
    , db    = require('nano')('http://localhost:5984/my_couch')
-   , app     = module.exports = express.createServer()
+   , app     = module.exports = express()
    ;
 
-app.get('/', function(request,response) {
-    db.get('foo', function (error, body, headers) {
-      if(error) { return response.send(error.message, error['status-code']); }
-      response.send(body, 200);
-    });
-  });
+app.get('/', function(req, res) {
+   db.get('foo', function (error, body, headers) {
+      if(error) {
+         res.status(error.statusCode);
+         return res.send(error.message); 
+      }
+      res.status(200);
+      res.send(body);
+   });
 });
 
 app.listen(3333);
-console.log('server is running. check expressjs.org for more cool tricks');
+console.log('server is running. check expressjs.com for more cool tricks');


### PR DESCRIPTION
This is a pull request to fix Issue #327

There were a few places where this file was out of date.

Express 4:
* express.createServer() has been deprecated
* passing the status via send() has been deprecated
* convention is to use 'req' and 'res' instead of 
  'request' and 'response'  

Nano 6:
* error['status-code'] is now error.statusCode

Also there was a syntax error (too many curly braces), and expressjs.org no longer exists / it is expressjs.com.