### PR TITLE
-start_range and end_range params in spatial query is not JSON.stringifyed

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -154,7 +154,7 @@ module.exports = exports = nano = function dbScope(cfg) {
 
     // http://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
     if (typeof opts.qs === 'object' && !_.isEmpty(opts.qs)) {
-      ['startkey', 'endkey', 'key', 'keys'].forEach(function(key) {
+      ['startkey', 'endkey', 'start_range', 'end_range', 'key', 'keys'].forEach(function(key) {
         if (key in opts.qs) {
           qs[key] = JSON.stringify(opts.qs[key]);
         }


### PR DESCRIPTION
Query that results in error.

_design/devices_near_geo_spatial/_spatial/points?start_range=-77.63441765259626&start_range=43.07415084441002&end_range=-77.59478134740375&end_range=43.103097155589985&limit=100 400

which results in error.
