### PR TITLE
Update nano.js

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -511,7 +511,10 @@ module.exports = exports = nano = function dbScope(cfg) {
       var paramsToEncode = ['counts', 'drilldown', 'group_sort', 'ranges', 'sort'];
       paramsToEncode.forEach(function(param) {
         if (param in qs) {
-          qs[param] = JSON.stringify(qs[param]);
+          // Don't encode strings as this could lead to have too many quotes
+          if (typeof qs[param] === 'object') {
+            qs[param] = JSON.stringify(qs[param]);
+          }
         }
       });
 


### PR DESCRIPTION
I found that encoding a string causes the JSON to be malformed with some calls (it encoded "created_at<string>" into "\"created_at<string>\"" and caused my DB to throw a 400 error).
Thus I believe that only objects parameters must be encoded.
