### PR TITLE
add reference to server in doc scope

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -740,7 +740,8 @@ module.exports = exports = nano = function dbScope(cfg) {
       search: viewSearch,
       spatial: viewSpatial,
       view: viewDocs,
-      viewWithList: viewWithList
+      viewWithList: viewWithList,
+      server: serverScope
     };
 
     docScope.view.compact = function(ddoc, cb) {


### PR DESCRIPTION
This PR adds the ability to get at the `serverScope` from a `docScope`. (which is not currently possible)

If you initialize nano with a db-name in your URL, (a common practice) it effectively becomes impossible to access the server scope:

``` js
var db = nano('http://localhost:5984/mydb');
// there is no way to access server scope, for something like server.auth()
```

In my case, I'm using a single database for my application, but I'm also trying to use `_users` for handling auth. I'm forced to create 2 different nano refs, which is just a little clumsy.

``` js
var server = nano('http://localhost:5984');
var db = server.use('mydb');

server.auth(); // user login
db.get(); // document retrieval
```

This PR adds support for the following:

``` js
var db = nano('http://localhost:5984/mydb');

db.server.auth(); // user login
db.get(); // document retrieval
```

While I could just say this is a convenience method, I think it's a little bit more than that since a common pattern like specifying a db-name completely excludes this functionality.
